### PR TITLE
fix path to example in test commands of Linux install

### DIFF
--- a/install/index.md
+++ b/install/index.md
@@ -62,7 +62,7 @@ Following commands can be used to download and test the latest distribution:
 $> curl -L $(curl -s -L -X GET https://api.github.com/repos/dynawo/dynawo/releases/latest | grep "Dynawo_Linux" | grep url | cut -d '"' -f 4) -o Dynawo_Linux_latest.zip
 $> unzip Dynawo_Linux_latest.zip
 $> cd dynawo
-$> ./dynawo.sh jobs-with-curves sources/examples/DynaWaltz/IEEE14/IEEE14_GeneratorDisconnections/IEEE14.jobs
+$> ./dynawo.sh jobs-with-curves examples/DynaWaltz/IEEE14/IEEE14_GeneratorDisconnections/IEEE14.jobs
 $> ./dynawo.sh help
 $> ./dynawo.sh jobs --help
 ```


### PR DESCRIPTION
Hello,
I've just installed and tested Dynaωo 1.6.0 on Linux using instructions from https://dynawo.github.io/install/.

The example test command:
```
$> ./dynawo.sh jobs-with-curves sources/examples/DynaWaltz/IEEE14/IEEE14_GeneratorDisconnections/IEEE14.jobs
```
fails because there is no remove upper level folder "source" in the zipped binary distribution: the "examples" folder is instead at the upper level.

Other than that, it works!